### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Deploy main to testing
         run: |
-          nix-shell -p rsync --run 'rsync -rt public website@ictunion.cz:/home/website/testing/var/www'
+          nix-shell -p rsync --run 'rsync -rt public/ website@ictunion.cz:/home/website/testing/var/www'
 
   deploy-production:
     needs: publish-code

--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -108,4 +108,4 @@ jobs:
 
       - name: Deploy main to production
         run: |
-          nix-shell -p rsync --run 'rsync -rtc public/ website@ictunion.cz:/home/website/testing/var/www'
+          nix-shell -p rsync --run 'rsync -rtc public/ website@ictunion.cz:/home/website/production/var/www'

--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: '0 2,14 * * *'
   workflow_dispatch:
-  push:
 
 jobs:
   publish-code:

--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Deploy main to testing
         run: |
-          nix-shell -p rsync --run 'rsync -rt public website@ictunion.cz:/home/website/testing/www'
+          nix-shell -p rsync --run 'rsync -rt public website@ictunion.cz:/home/website/testing/var/www'
 
   deploy-production:
     needs: publish-code

--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -104,8 +104,8 @@ jobs:
         run: date +%c
 
       - name: Build website
-        run: nix build
+        run: nix run
 
-      - name: Deploy production tag to production
+      - name: Deploy main to production
         run: |
-          nix-shell -p rsync --run 'rsync -rt result/var website@ictunion.cz:/home/website/production'
+          nix-shell -p rsync --run 'rsync -rt public/ website@ictunion.cz:/home/website/testing/var/www'

--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 2,14 * * *'
   workflow_dispatch:
+  push:
 
 jobs:
   publish-code:
@@ -69,11 +70,11 @@ jobs:
         run: date +%c
 
       - name: Build website
-        run: nix build
+        run: nix run
 
       - name: Deploy main to testing
         run: |
-          nix-shell -p rsync --run 'rsync -rt result/var website@ictunion.cz:/home/website/testing'
+          nix-shell -p rsync --run 'rsync -rt public website@ictunion.cz:/home/website/testing/www'
 
   deploy-production:
     needs: publish-code

--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Deploy main to testing
         run: |
-          nix-shell -p rsync --run 'rsync -rt public/ website@ictunion.cz:/home/website/testing/var/www'
+          nix-shell -p rsync --run 'rsync -rtc -I public/ website@ictunion.cz:/home/website/testing/var/www'
 
   deploy-production:
     needs: publish-code
@@ -108,4 +108,4 @@ jobs:
 
       - name: Deploy main to production
         run: |
-          nix-shell -p rsync --run 'rsync -rt public/ website@ictunion.cz:/home/website/testing/var/www'
+          nix-shell -p rsync --run 'rsync -rtc public/ website@ictunion.cz:/home/website/testing/var/www'


### PR DESCRIPTION
This will hopefully fix all the build cache issues for good. Now we don't run build of HTML files in sandbox anymore.